### PR TITLE
:sparkles: Add global state management

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,22 @@
 import "./App.css";
+import React, {useReducer} from 'react';
+import {
+  Context,
+  state,
+  reducer
+} from './store';
 import { Table } from "./components/Table/Table";
 import { Sidebar } from "./components/Sidebar/Sidebar";
 
 function App() {
+  const [store, dispatch] = useReducer(reducer, state);
   return (
-    <div className="App">
-      <Sidebar />
-      <Table />
-    </div>
+    <Context.Provider value={{ store, dispatch }}>
+      <div className="App">
+        <Sidebar />
+        <Table />
+      </div>
+    </Context.Provider>
   );
 }
 

--- a/src/components/City/CityRow.tsx
+++ b/src/components/City/CityRow.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import {CityProps} from '../../types/city.def';
 
-export class City extends React.Component {
+export class CityRow extends React.Component {
   constructor(props) {
     super(props);
     this.state = {

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1,5 +1,6 @@
 import "./Sidebar.css";
-import {useEffect, useState} from 'react';
+import {useContext, useEffect} from 'react';
+import {ActionType, Context} from '../../store';
 
 type Country = {
   name: string;
@@ -7,36 +8,35 @@ type Country = {
 }
 
 export const Sidebar = () => {
-  const [countries, setCountries] = useState<Country[]>([]);
-  const [country, setCountry] = useState<Country>({name: '', count: ''});
+  const { store, dispatch } = useContext(Context);
 
   useEffect(() => {
     fetch(import.meta.env.VITE_COUNTRIES_URL)
       .then((response) => response.json())
-      .then(setCountries);
+      .then((response) => dispatch({type: ActionType.SetCountries, payload: response}))
   }, []);
 
   const handleCountryChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    const selectedCountry = countries.find(country => country.name === event.target.value);
-    setCountry(selectedCountry);
+    const selectedCountry = store.countries.find((country: Country) => country.name === event.target.value);
+    dispatch({type: ActionType.SetCountry, payload: selectedCountry});
   }
 
   const resetCountry = () => {
-    setCountry({name: '', count: ''});
+    dispatch({type: ActionType.ResetCountry });
   }
 
   return (
     <div id="sidebar">
       <h2 className="font-black text-3xl mb-4">Cities App</h2>
       <div>
-        <button onClick={resetCountry} className="w-full bg-gray-100 p-2 rounded-md text-base uppercase font-bold tracking-widest hover:bg-gray-200">All Cities</button>
         <p className="my-4">Filter by country:</p>
-        <select name="" id="" value={country.name} onChange={handleCountryChange} className="w-full bg-gray-100 p-2 rounded-md">
-          <option selected value="">Select a country</option>
-          {countries.map((country) => (
+        <select name="" id="" value={store.country ? store.country.name : ''} onChange={handleCountryChange} className="w-full bg-gray-100 p-2 mb-3 rounded-md">
+          <option value="">Select a country</option>
+          {store.countries.map((country: Country) => (
             <option key={country.name} value={country.name}>{country.name} ({country.count})</option>
           ))}
         </select>
+        <button disabled={!store.country} onClick={resetCountry} className="w-full bg-gray-100 p-2 rounded-md text-base uppercase font-bold tracking-widest hover:bg-gray-200 disabled:bg-gray-50 disabled:text-gray-200 disabled:cursor-not-allowed">All Cities</button>
       </div>
     </div>
   );

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -1,16 +1,30 @@
 import "./Table.css";
-import { useEffect, useState } from "react";
-import {CityProps} from '../../types/city.def';
-import { City } from "../City/City";
+import {useContext, useEffect} from 'react';
+import { CityRow } from "../City/CityRow";
+import {ActionType, Context} from '../../store';
+import {City} from '../../types/city.def';
 
 export const Table = () => {
-  const [cities, setCities] = useState<CityProps[] | null>(null);
+  const { store, dispatch } = useContext(Context);
 
   useEffect(() => {
     fetch(import.meta.env.VITE_CITIES_URL)
       .then((response) => response.json())
-      .then(setCities);
+      .then((response) => dispatch({ type: ActionType.SetCities, payload: response }));
   }, []);
+
+  useEffect(() => {
+    let url = import.meta.env.VITE_CITIES_URL;
+
+    if (!!store.country) {
+      url = `${url}?country=${encodeURIComponent(store.country.name)}`;
+    }
+
+    dispatch({ type: ActionType.ResetCities }); // Reset cities to avoid strange behavior when changing country
+    fetch(url)
+      .then((response) => response.json())
+      .then((response) => dispatch({ type: ActionType.SetCities, payload: response }))
+  }, [store.country]);
 
   return (
     <div id="cities-table-wrapper">
@@ -21,9 +35,9 @@ export const Table = () => {
         </tr>
         </thead>
         <tbody>
-        {cities?.map((city, index) => (
+        { store.cities?.map((city: City, index: number) => (
           <tr key={index}>
-            <City city={city} />
+            <CityRow city={city} />
           </tr>
         ))}
         </tbody>

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,56 @@
+import {createContext} from 'react';
+import {Country} from '../types/country.def';
+import {City} from '../types/city.def';
+
+export enum ActionType {
+  SetCountry = 'SET_COUNTRY',
+  ResetCountry = 'RESET_COUNTRY',
+  SetCountries = 'SET_COUNTRIES',
+  SetCities = 'SET_CITIES',
+  ResetCities = 'RESET_CITIES',
+}
+
+export interface Action {
+  type: ActionType;
+  payload?: any;
+}
+
+export const state = {
+  country: null as Country | null,
+  countries: new Array<Country>(),
+  cities: new Array<City>()
+}
+
+export const reducer = (state, action: Action) => {
+  switch (action.type) {
+    case ActionType.SetCountry:
+      return {
+        ...state,
+        country: action.payload
+      }
+    case ActionType.ResetCountry:
+      return {
+        ...state,
+        country: null
+      }
+    case ActionType.SetCountries:
+      return {
+        ...state,
+        countries: action.payload
+      }
+    case ActionType.SetCities:
+      return {
+        ...state,
+        cities: action.payload
+      }
+    case ActionType.ResetCities:
+      return {
+        ...state,
+        cities: []
+      }
+    default:
+      return state
+  }
+}
+
+export const Context = createContext();

--- a/src/types/city.def.ts
+++ b/src/types/city.def.ts
@@ -1,4 +1,4 @@
-export interface CityProps {
+export interface City {
   name: string;
   country?: string;
   subcountry?: string;

--- a/src/types/country.def.ts
+++ b/src/types/country.def.ts
@@ -1,0 +1,4 @@
+export interface Country {
+  name: string;
+  count: string;
+}


### PR DESCRIPTION
:sparkles: Add global state management using createContext & useContext hooks
:sparkles: Add definition for Country
🚚 Rename City definition
🚚 Rename City to CityRow to avoid confusion with City interface
♻️ Update Sidebar to use global state instead of local state
♻️ Update Table to use global state instead of local state
💄 Refine Sidebar UI